### PR TITLE
Remove unnecessary Google Material since it is not used

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-beta02"
-    implementation 'com.google.android.material:material:1.4.0'
 }
 
 apply from: "publish.gradle"


### PR DESCRIPTION
Hello!

Thanks for creating the library and sharing it! 😄 

The project doesn't use android material at all and since it is fully compose I'm purging it from the project. Maybe it was part of the template and it wasn't removed?

That's what this PR is all about.

![](https://media.giphy.com/media/osjgQPWRx3cac/giphy.gif)